### PR TITLE
Fix: Use 0 for mark-excursion if mark is not defined

### DIFF
--- a/smart-shift.el
+++ b/smart-shift.el
@@ -170,7 +170,9 @@ STEP means move backwardly. Notice: It won't modify `kill-ring'."
                     (line-beginning-position 2))
                 (line-beginning-position 2)))
          (point-excursion (- (point) end))
-         (mark-excursion (- (mark) (point)))
+         (mark-excursion (if (use-region-p)
+                             (- (mark) (point))
+                           0))
          (text (delete-and-extract-region beg end)))
     ;; Shift text.
     (forward-line step)


### PR DESCRIPTION
When buffer's mark has never been set, `(mark)` returns `nil`:

> Return this buffer’s mark value as integer, or nil if never set.

This in turn causes `(- (mark) (point))` to fail with `(wrong-type-argument number-or-marker-p nil)`.
`mark-excursion` is only ever used further down the line if `(use-region-p)` is true.

I'm using emacs-27.0.91. After opening emacs, switching to `*scratch*` buffer and trying `smart-shift-up` or `smart-shift-down` said error occurrs. This PR fixes it.